### PR TITLE
monitoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,20 @@
             <version>5.21.0</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Source: https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-actuator -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <!-- Source: https://mvnrepository.com/artifact/io.micrometer/micrometer-registry-prometheus -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>1.16.3</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/cafediff/config/SecurityConfig.java
+++ b/src/main/java/com/cafediff/config/SecurityConfig.java
@@ -24,7 +24,8 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("cafediff/auth/**").permitAll()
+                        .requestMatchers("/cafediff/auth/**").permitAll()
+                        .requestMatchers("/cafediff/actuator/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,10 @@ logging.level.org.hibernate=DEBUG
 
 spring.config.import=file:src/main/resources/env.properties
 ENC_TOKEN = ${ENC_KEY}
+
+
+#Monitoring
+management.endpoints.web.exposure.include= *
+management.endpoint.health.show-details= always
+management.prometheus.metrics.export.enabled= true
+management.endpoints.web.base-path=/cafediff/actuator

--- a/src/main/resources/docker-compose.yml
+++ b/src/main/resources/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - 9090:9090
+    volumes:
+      - ./prometheus/tmp:/prometheus
+      - ./prometheus/config:/etc/prometheus
+    command: --config.file=/etc/prometheus/prometheus.yml --log.level=debug
+    # THIS LINE IS KEY:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana:latest-ubuntu
+    ports:
+      - 3000:3000
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./grafana/tmp:/var/lib/grafana

--- a/src/main/resources/prometheus/config/prometheus.yml
+++ b/src/main/resources/prometheus/config/prometheus.yml
@@ -1,0 +1,6 @@
+scrape_configs:
+  - job_name: 'spring-boot-application'
+    metrics_path: '/cafediff/actuator/prometheus'
+    scrape_interval: 15s # This can be adjusted based on our needs
+    static_configs:
+      - targets: ['host.docker.internal:8080']


### PR DESCRIPTION
#21 implemented monitoring with prometheus and grafana

## Summary by Sourcery

Add monitoring and metrics exposure for the Spring Boot application using Prometheus and Grafana.

New Features:
- Expose Spring Boot actuator endpoints, including Prometheus metrics, under a dedicated /cafediff/actuator path.
- Provide a Docker Compose setup for running Prometheus and Grafana preconfigured to scrape the application metrics.

Enhancements:
- Allow unauthenticated access to actuator endpoints required for monitoring.
- Integrate Micrometer Prometheus registry and Spring Boot Actuator dependencies into the application configuration.